### PR TITLE
Align YOY helper start date logic with ZC

### DIFF
--- a/ql/termstructures/inflation/inflationhelpers.cpp
+++ b/ql/termstructures/inflation/inflationhelpers.cpp
@@ -43,7 +43,7 @@ namespace QuantLib {
         const Date& start)
     : ZeroCouponInflationSwapHelper(
         quote, swapObsLag, start, maturity, std::move(calendar), paymentConvention,
-        std::move(dayCounter), zii, observationInterpolation) {}
+        dayCounter, zii, observationInterpolation) {}
 
     ZeroCouponInflationSwapHelper::ZeroCouponInflationSwapHelper(
         const Handle<Quote>& quote,
@@ -174,9 +174,9 @@ namespace QuantLib {
         CPI::InterpolationType interpolation,
         Handle<YieldTermStructure> nominalTermStructure,
         const Date& start)
-    : RelativeDateBootstrapHelper<YoYInflationTermStructure>(quote), swapObsLag_(swapObsLag),
-      maturity_(maturity), calendar_(std::move(calendar)), paymentConvention_(paymentConvention),
-      dayCounter_(std::move(dayCounter)), interpolation_(interpolation),
+    : RelativeDateBootstrapHelper<YoYInflationTermStructure>(quote, start == Date()),
+      swapObsLag_(swapObsLag), maturity_(maturity), calendar_(std::move(calendar)),
+      paymentConvention_(paymentConvention), dayCounter_(std::move(dayCounter)), interpolation_(interpolation),
       nominalTermStructure_(std::move(nominalTermStructure)), start_(start) {
         yii_ = yii->clone(termStructureHandle_);
         // We want to be notified of changes of fixings, but we don't


### PR DESCRIPTION
Update the logic in the `YearOnYearInflationSwapHelper` around the start date to align with the `ZeroCouponInflationSwapHelper`. If an explicit start date is provided and it is not the default `Date()`, set `updateDates_` to `false` in `RelativeDateBootstrapHelper`.

This is related to the pull request https://github.com/OpenSourceRisk/Engine/pull/326.