### PR TITLE
Resolve conflict markers in blackvariancecurve.cpp copyright header

### DIFF
--- a/ql/termstructures/volatility/equityfx/blackvariancecurve.cpp
+++ b/ql/termstructures/volatility/equityfx/blackvariancecurve.cpp
@@ -3,11 +3,8 @@
 /*
  Copyright (C) 2002, 2003, 2004 Ferdinando Ametrano
  Copyright (C) 2003 StatPro Italia srl
-<<<<<<< HEAD
  Copyright (C) 2025 AcadiaSoft, Inc.
-=======
  Copyright (C) 2026 Paolo D'Elia
->>>>>>> QL_1_42_1
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/


### PR DESCRIPTION
## Summary

- Commit [`4f35d3eab`](https://github.com/OpenSourceRisk/QuantLib/commit/4f35d3eab43cf3e02b69e8bd23354f64951f3a80) (`QPR-14001 merge ql 1.42.1 (Work in progress)`) left unresolved Git conflict markers in the copyright header of `ql/termstructures/volatility/equityfx/blackvariancecurve.cpp` (lines 6–10).
- The follow-up commit [`d500a5fdc`](https://github.com/OpenSourceRisk/QuantLib/commit/d500a5fdc079521a9bff7319bb03ac3d8b7f4acd) (`QPR-14001 bugfixes after QL upgrade to 1.42.1`) did not clean them up, and the markers remain on `master` tip.
- They fall inside the `/* */` copyright block so the file still compiles, but they trip pre-merge tooling that greps for `<<<<<<< HEAD` / `>>>>>>>` markers.

This PR keeps both copyright lines (`AcadiaSoft, Inc.` and `Paolo D'Elia`) and removes only the three marker lines. No executable code is changed.

## Before

\`\`\`
 Copyright (C) 2002, 2003, 2004 Ferdinando Ametrano
 Copyright (C) 2003 StatPro Italia srl
<<<<<<< HEAD
 Copyright (C) 2025 AcadiaSoft, Inc.
=======
 Copyright (C) 2026 Paolo D'Elia
>>>>>>> QL_1_42_1
\`\`\`

## After

\`\`\`
 Copyright (C) 2002, 2003, 2004 Ferdinando Ametrano
 Copyright (C) 2003 StatPro Italia srl
 Copyright (C) 2025 AcadiaSoft, Inc.
 Copyright (C) 2026 Paolo D'Elia
\`\`\`

## Test plan

- [x] File still compiles (no functional change — only comment lines edited)
- [x] No other files in the QuantLib tree contain unresolved `<<<<<<< HEAD` / `>>>>>>>` markers (verified via `git grep`)

The pre-existing commented-out markers in `test-suite/defaultprobabilitycurves.cpp` are intentional documentation of the v1.35 → HEAD API change (prefixed with `//` and surrounded by `/* */` to preserve the v1.35 alternative as a reference) and are not addressed by this PR.